### PR TITLE
Fix yaml examples and move away from global http client

### DIFF
--- a/CPU-POOLS.md
+++ b/CPU-POOLS.md
@@ -301,18 +301,21 @@ files and look like this:
 
 ```
      cpupools:
-       - name: "reserved"
-         cpus: "0-7,9"
+       - name: "ml"
+         cpus: "4-8,10"
+       - name: "avx512"
+         cpus: "*"
        - name: "default"
-         cpus: "8,10-12"
+         cpus: "@2"
 ```
 
 Note that the file format is subject to change in future versions of
-this tool. The above example would create two cpu pools, reserved and
-default, and assign cpus 0-7 (inclusive range) and 9 to pool reserved
-and cpus 8, 10, 11, and 12 to pool default. There are example profiles
-available in test/kubelet/pool-tool/samples directory of this
-repository.
+this tool. The above example would create two cpu pools, ml and avx512,
+in addition to the always-existing default pool. Cores 4-8 (inclusive
+range) and 10 would be assigned to ml pool, and two unspecified cores
+would be assigned to default pool. The rest of the available cores would
+be assiged to avx512 pool. There are example profiles available in
+test/kubelet/pool-tool/samples directory of this repository.
 
 Usage:
 ```

--- a/test/kubelet/pool-tool/samples/profile1.yaml
+++ b/test/kubelet/pool-tool/samples/profile1.yaml
@@ -1,5 +1,5 @@
 cpupools:
-  - name: "reserved"
-    cpus: "0"
-  - name: "default"
+  - name: "avx512"
     cpus: "1"
+  - name: "dpdk"
+    cpus: "2"

--- a/test/kubelet/pool-tool/samples/profile3.yaml
+++ b/test/kubelet/pool-tool/samples/profile3.yaml
@@ -3,5 +3,5 @@ cpupools:
     cpus: "0,1"
   - name: "avx512"
     cpus: "2,3-4"
-  - name: "dpdk"
-    cpus: "5-6"
+  - name: "default"
+    cpus: "@3"


### PR DESCRIPTION
Fix yaml examples and doc. They should now use all the features provided by the backend config. As suggested by @kad, do not use the global http client. Instead create a client which gets the transport config from k8s netutils.